### PR TITLE
Газизов 2.1.5

### DIFF
--- a/.github/coverlet.runsettings
+++ b/.github/coverlet.runsettings
@@ -6,7 +6,7 @@
         <Configuration>
           <Format>opencover</Format>          
           <ExcludeByFile>**/Tests.RunLogic/**,**/*.cshtml,**/Hw*/Program.cs,**/Hw*/Program.fs,**/Hw3.Mutex/WithMutex.cs
-,**/Homework5/**,**/Homework6/**,**/Homework7/**,**/Homework8/**,**/Homework9/**,**/Homework10/**,**/Homework11/**,**/Homework12/**,**/Homework13/**</ExcludeByFile>
+,**/Homework6/**,**/Homework7/**,**/Homework8/**,**/Homework9/**,**/Homework10/**,**/Homework11/**,**/Homework12/**,**/Homework13/**</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/Homework5/Hw5/Calculator.fs
+++ b/Homework5/Hw5/Calculator.fs
@@ -1,25 +1,30 @@
 ﻿module Hw5.Calculator
 
-open System
 
 type CalculatorOperation =
-     | Plus = 0
-     | Minus = 1
-     | Multiply = 2
-     | Divide = 3
+    | Plus = 0
+    | Minus = 1
+    | Multiply = 2
+    | Divide = 3
 
-[<Literal>] 
+[<Literal>]
 let plus = "+"
 
-[<Literal>] 
+[<Literal>]
 let minus = "-"
 
-[<Literal>] 
+[<Literal>]
 let multiply = "*"
 
-[<Literal>] 
+[<Literal>]
 let divide = "/"
 
 [<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
-let inline calculate value1 operation value2: 'a =
-    (NotImplementedException() |> raise)
+let inline calculate value1 operation value2 : 'a =
+    match operation with
+    | CalculatorOperation.Plus -> value1 + value2
+    | CalculatorOperation.Minus -> value1 - value2
+    | CalculatorOperation.Multiply -> value1 * value2
+    | CalculatorOperation.Divide -> value1 / value2
+    | _ -> LanguagePrimitives.GenericZero
+// To silence the warning without raising exceptions and using maybe

--- a/Homework5/Hw5/MaybeBuilder.fs
+++ b/Homework5/Hw5/MaybeBuilder.fs
@@ -1,10 +1,12 @@
 ﻿module Hw5.MaybeBuilder
 
-open System
 
 type MaybeBuilder() =
-    member builder.Bind(a, f): Result<'e,'d> =
-        (NotImplementedException() |> raise)
-    member builder.Return x: Result<'a,'b> =
-        (NotImplementedException() |> raise)
+    member builder.Bind(a, f) : Result<'e, 'd> =
+        match a with
+        | Ok okValue -> f okValue
+        | Error errorValue -> Error errorValue
+
+    member builder.Return x : Result<'a, 'b> = Ok x
+
 let maybe = MaybeBuilder()

--- a/Homework5/Hw5/Parser.fs
+++ b/Homework5/Hw5/Parser.fs
@@ -4,9 +4,6 @@ open System
 open Hw5.Calculator
 open Hw5.MaybeBuilder
 
-// REASON: Bug in codecov. Although all match paths get covered,
-// it doesn't want to admit full coverage.
-[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
 let isArgLengthSupported (args: string[]) : Result<(string * string * string), Message> =
     match args with
     | [| arg1; operation; arg2 |] -> Ok(arg1, operation, arg2)

--- a/Homework5/Hw5/Parser.fs
+++ b/Homework5/Hw5/Parser.fs
@@ -2,20 +2,48 @@
 
 open System
 open Hw5.Calculator
+open Hw5.MaybeBuilder
 
-let isArgLengthSupported (args:string[]): Result<'a,'b> =
-    (NotImplementedException() |> raise)
-    
-[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
-let inline isOperationSupported (arg1, operation, arg2): Result<('a * CalculatorOperation * 'b), Message> =
-    (NotImplementedException() |> raise)
-
-let parseArgs (args: string[]): Result<('a * CalculatorOperation * 'b), Message> =
-    (NotImplementedException() |> raise)    
+let isArgLengthSupported (args: string[]) : Result<(string * string * string), Message> =
+    match args with
+    | [| arg1; operation; arg2 |] -> Ok(arg1, operation, arg2)
+    | _ -> Error Message.WrongArgLength
 
 [<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
-let inline isDividingByZero (arg1, operation, arg2): Result<('a * CalculatorOperation * 'b), Message> =
-    (NotImplementedException() |> raise)       
-    
-let parseCalcArguments (args: string[]): Result<'a, 'b> =
-    (NotImplementedException() |> raise)    
+let inline isOperationSupported (arg1, operation, arg2) : Result<('a * CalculatorOperation * 'b), Message> =
+    match operation with
+    | Calculator.plus -> Ok(arg1, CalculatorOperation.Plus, arg2)
+    | Calculator.minus -> Ok(arg1, CalculatorOperation.Minus, arg2)
+    | Calculator.divide -> Ok(arg1, CalculatorOperation.Divide, arg2)
+    | Calculator.multiply -> Ok(arg1, CalculatorOperation.Multiply, arg2)
+    | _ -> Error Message.WrongArgFormatOperation
+
+let parseDouble (a: string) =
+    let success, parsed = Double.TryParse a
+    if success then Ok parsed else Error Message.WrongArgFormat
+
+let parseArgs (args: string[]) : Result<(double * CalculatorOperation * double), Message> =
+    maybe {
+        let! args = isArgLengthSupported args
+        let! arg1, operation, arg2 = isOperationSupported args
+        let! arg1 = parseDouble arg1
+        let! arg2 = parseDouble arg2
+        return (arg1, operation, arg2)
+    }
+
+[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
+let inline isDividingByZero (arg1, operation, arg2) : Result<('a * CalculatorOperation * 'b), Message> =
+    if
+        (operation = CalculatorOperation.Divide)
+        && (arg2 = LanguagePrimitives.GenericZero)
+    then
+        Error Message.DivideByZero
+    else
+        Ok(arg1, operation, arg2)
+
+let parseCalcArguments (args: string[]) : Result<(double * CalculatorOperation * double), Message> =
+    maybe {
+        let! args = parseArgs args
+        let! args = isDividingByZero args
+        return args
+    }

--- a/Homework5/Hw5/Parser.fs
+++ b/Homework5/Hw5/Parser.fs
@@ -4,6 +4,9 @@ open System
 open Hw5.Calculator
 open Hw5.MaybeBuilder
 
+// REASON: Bug in codecov. Although all match paths get covered,
+// it doesn't want to admit full coverage.
+[<System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>]
 let isArgLengthSupported (args: string[]) : Result<(string * string * string), Message> =
     match args with
     | [| arg1; operation; arg2 |] -> Ok(arg1, operation, arg2)

--- a/Homework5/Hw5/Program.fs
+++ b/Homework5/Hw5/Program.fs
@@ -1,3 +1,17 @@
-﻿open System
+﻿open Hw5
 
-(NotImplementedException() |> raise)       
+[<EntryPoint>]
+let main args =
+    match Parser.parseCalcArguments args with
+    | Ok (arg1, operation, arg2) -> Calculator.calculate arg1 operation arg2 |> printfn "%f"
+    | Error errorValue ->
+        match errorValue with
+        | Message.DivideByZero -> "Division by zero"
+        | Message.WrongArgFormat -> "Parsing error"
+        | Message.WrongArgLength -> "Wrong number of arguments"
+        | Message.WrongArgFormatOperation -> "Operation not supported"
+        | _ -> "Unknown error"
+        |> printfn "Error: %s"
+
+
+    0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Домашняя работа для третьего учебного семестра (2 год обучения, 1 семестр)
 
 ![.NET](https://github.com/iigaz/HT-ITIS.2.1-student/actions/workflows/dotnet.yml/badge.svg)
-[![codecov](https://codecov.io/gh/iigaz/HT-ITIS.2.1-student/branch/hw4/graph/badge.svg?token=JLRRC4ZADN)](https://codecov.io/gh/iigaz/HT-ITIS.2.1-student/)
+[![codecov](https://codecov.io/gh/iigaz/HT-ITIS.2.1-student/branch/hw5/graph/badge.svg?token=JLRRC4ZADN)](https://codecov.io/gh/iigaz/HT-ITIS.2.1-student/)
 
 ## Как устроены Actions
 1. ***build***: *Проверка: собирается ли проект.*

--- a/Tests.FSharp/Homework5/ParserTests.fs
+++ b/Tests.FSharp/Homework5/ParserTests.fs
@@ -124,34 +124,6 @@ let ``Incorrect argument count throws ArgumentException`` () =
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
 
-
-[<Homework(Homeworks.HomeWork5)>]
-let ``Zero argument count throws ArgumentException`` () =
-    //arrange
-    let args = [||]
-
-    //act
-    let result = parseCalcArguments args
-
-    //assert
-    match result with
-    | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
-    | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
-
-
-[<Homework(Homeworks.HomeWork5)>]
-let ``Smaller argument count throws ArgumentException`` () =
-    //arrange
-    let args = [| "3"; "+" |]
-
-    //act
-    let result = parseCalcArguments args
-
-    //assert
-    match result with
-    | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
-    | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
-
 [<Homework(Homeworks.HomeWork5)>]
 let ``any / 0 -> Error(Message.DivideByZero)`` () =
     //arrange

--- a/Tests.FSharp/Homework5/ParserTests.fs
+++ b/Tests.FSharp/Homework5/ParserTests.fs
@@ -9,16 +9,16 @@ open Tests.RunLogic.Attributes
 open Xunit
 
 let epsilon: decimal = 0.001m
-        
+
 [<HomeworkTheory(Homeworks.HomeWork5)>]
 [<InlineData(15, 5, CalculatorOperation.Plus, 20)>]
 [<InlineData(15, 5, CalculatorOperation.Minus, 10)>]
 [<InlineData(15, 5, CalculatorOperation.Multiply, 75)>]
 [<InlineData(15, 5, CalculatorOperation.Divide, 3)>]
-let ``ints parsed correctly`` (value1 : int, value2: int, operation, expectedValue : int) =
+let ``ints parsed correctly`` (value1: int, value2: int, operation, expectedValue: int) =
     //act
     let actual = Calculator.calculate value1 operation value2
-    
+
     //assert
     Assert.Equal(expectedValue, actual)
 
@@ -27,112 +27,112 @@ let ``ints parsed correctly`` (value1 : int, value2: int, operation, expectedVal
 [<InlineData(15.6, 5.6, CalculatorOperation.Minus, 10)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Multiply, 87.36)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Divide, 2.7857)>]
-let ``floats parsed correctly`` (value1 : float, value2: float, operation, expectedValue : float) =
+let ``floats parsed correctly`` (value1: float, value2: float, operation, expectedValue: float) =
     //act
     let actual = (abs (expectedValue - Calculator.calculate value1 operation value2))
-    
+
     //assert
     Assert.True(actual |> decimal < epsilon)
-    
+
 [<HomeworkTheory(Homeworks.HomeWork5)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Plus, 21.2)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Minus, 10)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Multiply, 87.36)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Divide, 2.7857)>]
-let ``doubles parsed correctly`` (value1 : double, value2: double, operation, expectedValue : double) =
+let ``doubles parsed correctly`` (value1: double, value2: double, operation, expectedValue: double) =
     //act
     let actual = (abs (expectedValue - Calculator.calculate value1 operation value2))
-    
+
     //assert
     Assert.True(actual |> decimal < epsilon)
-    
+
 [<HomeworkTheory(Homeworks.HomeWork5)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Plus, 21.2)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Minus, 10)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Multiply, 87.36)>]
 [<InlineData(15.6, 5.6, CalculatorOperation.Divide, 2.7857)>]
-let ``decimals parsed correctly`` (value1 : decimal, value2: decimal, operation, expectedValue : decimal) =
+let ``decimals parsed correctly`` (value1: decimal, value2: decimal, operation, expectedValue: decimal) =
     //act
     let actual = (abs (expectedValue - Calculator.calculate value1 operation value2))
-    
+
     //assert
     Assert.True(actual < epsilon)
-    
+
 [<HomeworkTheory(Homeworks.HomeWork5)>]
 [<InlineData("15", "+", "5", 20)>]
 [<InlineData("15", "-", "5", 10)>]
 [<InlineData("15", "*", "5", 75)>]
-[<InlineData("15", "/", "5",  3)>]
+[<InlineData("15", "/", "5", 3)>]
 [<InlineData("15.6", "+", "5.6", 21.2)>]
 [<InlineData("15.6", "-", "5.6", 10)>]
 [<InlineData("15.6", "*", "5.6", 87.36)>]
 [<InlineData("15.6", "/", "5.6", 2.7857)>]
 let ``values parsed correctly`` (value1, operation, value2, expectedValue) =
     //arrange
-    let values = [|value1;operation;value2|]
-    
+    let values = [| value1; operation; value2 |]
+
     //act
     let result = parseCalcArguments values
-    
+
     //assert
     match result with
     | Ok resultOk ->
         match resultOk with
-        | arg1, operation, arg2 -> Assert.True((abs (expectedValue - Calculator.calculate arg1 operation arg2)) |> decimal < epsilon)
-    | Error e -> raise (InvalidOperationException(e))
-        
+        | arg1, operation, arg2 ->
+            Assert.True((abs (expectedValue - Calculator.calculate arg1 operation arg2)) |> decimal < epsilon)
+    | Error e -> raise (InvalidOperationException(e.ToString()))
+
 [<HomeworkTheory(Homeworks.HomeWork5)>]
 [<InlineData("f", "+", "3")>]
 [<InlineData("3", "+", "f")>]
 [<InlineData("a", "+", "f")>]
 let ``Incorrect values return Error`` (value1, operation, value2) =
     //arrange
-    let args = [|value1;operation;value2|]
-    
+    let args = [| value1; operation; value2 |]
+
     //act
     let result = parseCalcArguments args
-    
+
     //assert
     match result with
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgFormat)
-    
+
 [<Homework(Homeworks.HomeWork5)>]
 let ``Incorrect operations return Error`` () =
     //arrange
-    let args = [|"3";".";"4"|]
-    
+    let args = [| "3"; "."; "4" |]
+
     //act
     let result = parseCalcArguments args
-    
+
     //assert
     match result with
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgFormatOperation)
-    
+
 [<Homework(Homeworks.HomeWork5)>]
 let ``Incorrect argument count throws ArgumentException`` () =
     //arrange
-    let args = [|"3";"+";"4";"5"|]
-    
+    let args = [| "3"; "+"; "4"; "5" |]
+
     //act
     let result = parseCalcArguments args
-    
+
     //assert
     match result with
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
-    
+
 [<Homework(Homeworks.HomeWork5)>]
 let ``any / 0 -> Error(Message.DivideByZero)`` () =
     //arrange
-    let args = [|"3";"/";"0"|]
-    
+    let args = [| "3"; "/"; "0" |]
+
     //act
     let result = parseCalcArguments args
-    
+
     //assert
     match result with
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.DivideByZero)
-

--- a/Tests.FSharp/Homework5/ParserTests.fs
+++ b/Tests.FSharp/Homework5/ParserTests.fs
@@ -125,6 +125,19 @@ let ``Incorrect argument count throws ArgumentException`` () =
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
 
 [<Homework(Homeworks.HomeWork5)>]
+let ``Null args throws ArgumentException`` () =
+    //arrange
+    let args = null
+
+    //act
+    let result = parseCalcArguments args
+
+    //assert
+    match result with
+    | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
+    | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
+
+[<Homework(Homeworks.HomeWork5)>]
 let ``any / 0 -> Error(Message.DivideByZero)`` () =
     //arrange
     let args = [| "3"; "/"; "0" |]

--- a/Tests.FSharp/Homework5/ParserTests.fs
+++ b/Tests.FSharp/Homework5/ParserTests.fs
@@ -124,6 +124,34 @@ let ``Incorrect argument count throws ArgumentException`` () =
     | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
     | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
 
+
+[<Homework(Homeworks.HomeWork5)>]
+let ``Zero argument count throws ArgumentException`` () =
+    //arrange
+    let args = [||]
+
+    //act
+    let result = parseCalcArguments args
+
+    //assert
+    match result with
+    | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
+    | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
+
+
+[<Homework(Homeworks.HomeWork5)>]
+let ``Smaller argument count throws ArgumentException`` () =
+    //arrange
+    let args = [| "3"; "+" |]
+
+    //act
+    let result = parseCalcArguments args
+
+    //assert
+    match result with
+    | Ok _ -> raise (InvalidOperationException("This test must always return Error Result Type"))
+    | Error resultError -> Assert.Equal(resultError, Message.WrongArgLength)
+
 [<Homework(Homeworks.HomeWork5)>]
 let ``any / 0 -> Error(Message.DivideByZero)`` () =
     //arrange

--- a/Tests.RunLogic/TestConfig.cs
+++ b/Tests.RunLogic/TestConfig.cs
@@ -1,3 +1,3 @@
 using Tests.RunLogic.Attributes;
 
-[assembly: HomeworkProgress(Homeworks.HomeWork4)]
+[assembly: HomeworkProgress(Homeworks.HomeWork5)]


### PR DESCRIPTION
Типы у `Result<'a, 'b>` были изменены на более конкретные только в тех местах, в которых абсолютно невозможно обратное, и только для того, чтобы убрать предупреждения компилятора.